### PR TITLE
avoid generic names as export or import

### DIFF
--- a/quintagroup/transmogrifier/configure.zcml
+++ b/quintagroup/transmogrifier/configure.zcml
@@ -138,13 +138,13 @@
     <adapter factory=".portlets.PortletAssignmentExportImportHandler" />
 
     <transmogrifier:registerConfig
-        name="export"
+        name="quintagroup.transmogrifier-export"
         title="Export pipeline configuration"
         description="This is a Plone content export pipeline configuration."
         configuration="export.cfg"
         />
 
-    <!-- We registry this export step in zcml and it will override Plone's standard 
+    <!-- We registry this export step in zcml and it will override Plone's standard
          Content export step. Than we need to go in ZMI to Manage tab of portal_setup
          tool and delete old step. (I also detected that steps registered in zcml
          overriede those registered in profile without deleting them on manage tab)
@@ -157,7 +157,7 @@
         />
 
     <transmogrifier:registerConfig
-        name="import"
+        name="quintagroup.transmogrifier-import"
         title="Import pipeline configuration"
         description="This is a Plone content import pipeline configuration."
         configuration="import.cfg"

--- a/quintagroup/transmogrifier/exportimport.py
+++ b/quintagroup/transmogrifier/exportimport.py
@@ -20,8 +20,8 @@ from Products.GenericSetup.interfaces import IFilesystemImporter
 from quintagroup.transmogrifier.writer import WriterSection
 from quintagroup.transmogrifier.configview import ANNOKEY
 
-EXPORT_CONFIG = 'export'
-IMPORT_CONFIG = 'import'
+EXPORT_CONFIG = 'quintagroup.transmogrifier-export'
+IMPORT_CONFIG = 'quintagroup.transmogrifier-import'
 
 CONFIGFILE = None
 def registerPersistentConfig(site, type_):


### PR DESCRIPTION
This way, we avoid clashes with other product that register pipelines such as transmogrify.dexterity that does the same.

Ref: https://github.com/collective/transmogrify.dexterity/pull/26
